### PR TITLE
fix: /api/submit 경로에 대해 CSRF 검증 해제

### DIFF
--- a/backend/src/main/java/com/example/coby/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/coby/config/SecurityConfig.java
@@ -20,7 +20,11 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .csrf(csrf -> csrf
+                        .ignoringRequestMatchers("/api/submit")
+                )
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/ws/**").permitAll()
                         .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth2 -> oauth2


### PR DESCRIPTION
개발 중 편의를 위해 임시로 CSRF 토큰 검증을 해제하였고, 추후 프론트에서 CSRF 토큰을 실어서 보내는 등 해결해야함