### PR TITLE
fix restart Logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ out/
 
 # IntelliJ config
 *.xml
-
+*.sh
 **/.env.idea/
 backend/.env
 *.pem

--- a/backend/src/main/java/com/example/coby/controller/RoomController.java
+++ b/backend/src/main/java/com/example/coby/controller/RoomController.java
@@ -4,6 +4,7 @@ import com.example.coby.dto.*;
 import com.example.coby.entity.Problem;
 import com.example.coby.entity.Room;
 import com.example.coby.repository.SubmissionRepository;
+import com.example.coby.service.RestartService;
 import com.example.coby.service.RoomService;
 import com.example.coby.service.SubmissionService;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +12,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/rooms")
@@ -21,6 +24,7 @@ public class RoomController {
     private final RoomService roomService;
     private final SubmissionService submissionService;
     private final SubmissionRepository submissionRepository;
+    private final RestartService restartService;
 
     @GetMapping
     public List<RoomResponse> getRooms() {
@@ -53,6 +57,29 @@ public class RoomController {
         }
         return ResponseEntity.ok(ProblemResponse.from(problem));
     }
+
+    @PostMapping("/restart/{roomId}")
+    public ResponseEntity<Map<String, Object>> requestRestart(
+            @PathVariable Long roomId,
+            @RequestBody Map<String, Long> request) {
+
+        try {
+            Long userId = request.get("userId");
+            restartService.initiateRestart(roomId, userId);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", true);
+            response.put("message", "재시작 투표가 시작되었습니다.");
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", false);
+            response.put("message", e.getMessage());
+            return ResponseEntity.badRequest().body(response);
+        }
+    }
+
     @PostMapping("/{id}/change-problem")
     public ResponseEntity<RoomResponse> changeRoomProblem(@PathVariable Long id) {
         Room updatedRoom = roomService.changeRoomProblem(id);

--- a/backend/src/main/java/com/example/coby/dto/CreateRoomRequest.java
+++ b/backend/src/main/java/com/example/coby/dto/CreateRoomRequest.java
@@ -1,9 +1,11 @@
 package com.example.coby.dto;
 
 import com.example.coby.entity.RoomStatus;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
 public class CreateRoomRequest {
     private String roomName;
     private String difficulty;

--- a/backend/src/main/java/com/example/coby/dto/WsMessageDto.java
+++ b/backend/src/main/java/com/example/coby/dto/WsMessageDto.java
@@ -16,5 +16,8 @@ public record WsMessageDto(
         Boolean isReady,
         Boolean isHost,
         String content,
+        Boolean isJoin,  // 재시작 투표용
+        Long newRoomId,  // 새 방 ID
+        Boolean success, // 재시작 성공 여부
         List<RoomUserResponse> users
 ) {}

--- a/backend/src/main/java/com/example/coby/service/RestartService.java
+++ b/backend/src/main/java/com/example/coby/service/RestartService.java
@@ -1,0 +1,258 @@
+package com.example.coby.service;
+
+import com.example.coby.dto.CreateRoomRequest;
+import com.example.coby.entity.*;
+import com.example.coby.repository.*;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RestartService {
+
+    private final RoomService roomService;
+    private final RoomUserRepository roomUserRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    private final Map<Long, RestartSession> restartSessions = new ConcurrentHashMap<>();
+    private static final int VOTE_TIMEOUT_SECONDS = 10;
+
+    /**
+     * 재시작 요청 시작
+     */
+    @Transactional
+    public void initiateRestart(Long roomId, Long initiatorId) {
+        // 이미 진행 중인 투표 확인
+        if (restartSessions.containsKey(roomId)) {
+            throw new IllegalStateException("이미 재시작 투표가 진행 중입니다.");
+        }
+
+        // 현재 방의 모든 참가자 조회
+        List<RoomUser> roomUsers = roomUserRepository.findByRoomId(roomId);
+
+        if (roomUsers.isEmpty()) {
+            throw new IllegalStateException("참가자가 없는 방입니다.");
+        }
+
+        List<Long> participantIds = roomUsers.stream()
+                .map(RoomUser::getUserId)
+                .toList();
+
+        // 투표 세션 생성
+        RestartSession session = new RestartSession(roomId, participantIds, initiatorId);
+        restartSessions.put(roomId, session);
+
+        // 모든 참가자에게 투표 시작 알림
+        Map<String, Object> message = new HashMap<>();
+        message.put("type", "RestartStarted");
+        message.put("initiatorId", initiatorId);
+
+        messagingTemplate.convertAndSend("/topic/restart/" + roomId, message);
+
+        log.info("방 {}에 재시작 투표가 시작되었습니다. 개시자: {}", roomId, initiatorId);
+
+        // 타임아웃 스케줄링
+        scheduleTimeout(roomId);
+    }
+
+    /**
+     * 투표 처리
+     */
+    public void processVote(Long roomId, Long userId, boolean join) {
+        RestartSession session = restartSessions.get(roomId);
+
+        if (session == null) {
+            throw new IllegalStateException("진행 중인 투표가 없습니다.");
+        }
+
+        // 투표 기록
+        session.addVote(userId, join);
+
+        // 투표 브로드캐스트
+        Map<String, Object> voteMessage = new HashMap<>();
+        voteMessage.put("type", "Vote");
+        voteMessage.put("userId", userId);
+        voteMessage.put("join", join);
+
+        messagingTemplate.convertAndSend("/topic/restart/" + roomId, voteMessage);
+
+        log.info("사용자 {}가 투표했습니다. join={}", userId, join);
+
+        // 모든 참가자가 투표했는지 확인
+        if (session.isAllVoted()) {
+            completeRestart(roomId, session);
+        }
+    }
+
+    /**
+     * 재시작 완료 처리
+     */
+    @Transactional
+    public void completeRestart(Long roomId, RestartSession session) {
+        try {
+            boolean allAccepted = session.isAllAccepted();
+
+            Map<String, Object> resultMessage = new HashMap<>();
+            resultMessage.put("type", "RestartResult");
+
+            if (allAccepted) {
+                // 새 방 생성
+                Long newRoomId = createNewRoomFromOld(roomId, session.getAcceptedUserIds());
+
+                resultMessage.put("success", true);
+                resultMessage.put("newRoomId", newRoomId);
+
+                log.info("재시작 성공! 새 방 ID: {}", newRoomId);
+
+            } else {
+                // 거부자가 있는 경우
+                resultMessage.put("success", false);
+                resultMessage.put("newRoomId", null);
+
+                log.info("재시작 거부됨. 거부자가 있습니다.");
+            }
+
+            messagingTemplate.convertAndSend("/topic/restart/" + roomId, resultMessage);
+
+        } finally {
+            // 세션 정리
+            restartSessions.remove(roomId);
+        }
+    }
+
+    /**
+     * 타임아웃 스케줄링
+     */
+    private void scheduleTimeout(Long roomId) {
+        CompletableFuture.runAsync(() -> {
+            try {
+                Thread.sleep(VOTE_TIMEOUT_SECONDS * 1000);
+
+                RestartSession session = restartSessions.get(roomId);
+                if (session != null) {
+                    log.info("투표 타임아웃. 미투표자 자동 거부 처리 중...");
+
+                    // 투표하지 않은 사람은 자동으로 거부 처리
+                    session.getParticipantIds().forEach(userId -> {
+                        if (!session.hasVoted(userId)) {
+                            session.addVote(userId, false);
+                            log.info("사용자 {} 자동 거부 처리", userId);
+                        }
+                    });
+
+                    completeRestart(roomId, session);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("타임아웃 스케줄링 중 인터럽트 발생", e);
+            }
+        });
+    }
+
+    /**
+     * 새 방 생성 (기존 RoomService 활용)
+     */
+    @Transactional
+    public Long createNewRoomFromOld(Long oldRoomId, List<Long> acceptedUserIds) {
+        // 기존 방 정보 조회
+        Room oldRoom = roomService.getRoom(oldRoomId);
+
+        if (oldRoom == null) {
+            throw new IllegalStateException("기존 방을 찾을 수 없습니다.");
+        }
+
+        // 방장 찾기 (기존 방장 또는 첫 번째 수락자)
+        Long hostId = acceptedUserIds.stream()
+                .filter(userId -> roomService.isUserHost(oldRoomId, userId))
+                .findFirst()
+                .orElse(acceptedUserIds.get(0));
+
+        // 새 방 생성 요청 객체 생성
+        CreateRoomRequest createRequest = CreateRoomRequest.builder()
+                .roomName(oldRoom.getRoomName() + " (재대결)")
+                .difficulty(oldRoom.getDifficulty())
+                .timeLimit(oldRoom.getTimeLimit())
+                .maxParticipants(oldRoom.getMaxParticipants())
+                .currentPart(0)
+                .status(RoomStatus.WAITING)
+                .isPrivate(oldRoom.isPrivate())
+                .password(oldRoom.getPassword())
+                .itemMode(oldRoom.isItemMode())
+                .build();
+
+        // 새 방 생성 (랜덤 문제 자동 할당됨)
+        Room newRoom = roomService.createRoom(createRequest);
+
+        log.info("새 방 생성 완료. ID: {}, 문제: {}", newRoom.getId(), newRoom.getProblem().getTitle());
+
+        // 방장을 먼저 추가 (joinRoom은 첫 번째 참가자를 자동으로 방장으로 설정)
+        roomService.joinRoom(newRoom.getId(), hostId);
+
+        // 나머지 수락한 참가자들 추가
+        for (Long userId : acceptedUserIds) {
+            if (!userId.equals(hostId)) {
+                roomService.joinRoom(newRoom.getId(), userId);
+            }
+        }
+
+        log.info("모든 참가자가 새 방에 추가되었습니다. 총 {}명", acceptedUserIds.size());
+
+        return newRoom.getId();
+    }
+
+    /**
+     * 투표 세션 클래스
+     */
+    @Getter
+    public static class RestartSession {
+        private final Long roomId;
+        private final List<Long> participantIds;
+        private final Long initiatorId;
+        private final Map<Long, Boolean> votes;
+        private final LocalDateTime createdAt;
+
+        public RestartSession(Long roomId, List<Long> participantIds, Long initiatorId) {
+            this.roomId = roomId;
+            this.participantIds = new ArrayList<>(participantIds);
+            this.initiatorId = initiatorId;
+            this.votes = new ConcurrentHashMap<>();
+            this.createdAt = LocalDateTime.now();
+        }
+
+        public void addVote(Long userId, boolean join) {
+            if (!participantIds.contains(userId)) {
+                throw new IllegalArgumentException("방 참가자가 아닙니다: " + userId);
+            }
+            votes.put(userId, join);
+        }
+
+        public boolean hasVoted(Long userId) {
+            return votes.containsKey(userId);
+        }
+
+        public boolean isAllVoted() {
+            return votes.size() == participantIds.size();
+        }
+
+        public boolean isAllAccepted() {
+            return votes.values().stream().allMatch(Boolean::booleanValue);
+        }
+
+        public List<Long> getAcceptedUserIds() {
+            return votes.entrySet().stream()
+                    .filter(Map.Entry::getValue)
+                    .map(Map.Entry::getKey)
+                    .toList();
+        }
+    }
+}

--- a/frontend/src/pages/WebSocket/WebSocketContext.jsx
+++ b/frontend/src/pages/WebSocket/WebSocketContext.jsx
@@ -24,9 +24,13 @@ export const WebSocketProvider = ({ children }) => {
   // 강퇴 여부 및 현재 사용자 ID를 저장
   const [forcedOut, setForcedOut] = useState(false)
   const currentUserIdRef = useRef(null);
+  const currentUserInfoRef = useRef(null);
   // 시스템 토스트 메시지와 자발적 퇴장을 구분하기 위한 ref
   const [systemMessage, setSystemMessage] = useState(null);
   const voluntaryLeaveRef = useRef(false);
+  // 재시작 용 변수
+  const [restartModal, setRestartModal] = useState(false);
+  const [votes, setVotes] = useState({}); // { userId: true/false }
 
   // 컴포넌트가 마운트될 때 서버와 WebSocket 연결을 설정
   useEffect(() => {
@@ -70,6 +74,7 @@ export const WebSocketProvider = ({ children }) => {
 
     // 현재 사용자 ID 저장
     currentUserIdRef.current = userInfo.userId;
+    currentUserInfoRef.current = userInfo;
 
     // 새로운 방에 참여할 때 기존 메시지와 유저 목록, 게임 시작 상태를 초기화합니다.
     setMessages([]);
@@ -138,9 +143,46 @@ export const WebSocketProvider = ({ children }) => {
             break;
           default:
             break;
-
         }
       });
+
+      // 재시작 로직
+      const restartSub = clientRef.current.subscribe(`/topic/restart/${roomId}`, (msg) => {
+          const data = JSON.parse(msg.body);
+
+          switch (data.type) {
+              case "Vote":
+                  setVotes((prev) => ({ ...prev, [data.userId]: data.join }));
+                  break;
+              case "RestartStarted":
+                  setVotes({});
+                  setRestartModal(true);
+                  break;
+              case "RestartResult":
+                  setRestartModal(false);
+                  if (data.newRoomId) {
+                      // 기존 room 구독 해제
+                      cleanupRoom(roomId);
+                      leaveRoom(roomId, currentUserIdRef.current);
+                      // 새 방으로 자동 이동
+                      const newRoomIdStr = String(data.newRoomId);
+
+                      // CustomEvent로 페이지 이동 알림
+                      window.dispatchEvent(new CustomEvent('navigateToWaitingRoom', {
+                        detail: { roomId: newRoomIdStr,
+                        userId: data.userId}
+                      }));
+                  } else {
+                      // 거부 or 타임아웃 → 메인으로 이동
+                      cleanupRoom(roomId);
+                      window.dispatchEvent(new CustomEvent('navigateToMain'));
+                  }
+                  break;
+              default:
+                  break;
+          }
+      });
+
 
       // 서버로부터 현재 방의 유저 목록을 받아오기 위한 구독
       const userSub = clientRef.current.subscribe(`/user/queue/room/${roomId}/users`, (msg) => {
@@ -162,7 +204,7 @@ export const WebSocketProvider = ({ children }) => {
           setForcedOut(true);
         }
       });
-      subscriptionsRef.current[roomId] = [roomSub, userSub, kickedSub];
+      subscriptionsRef.current[roomId] = [roomSub, userSub, kickedSub, restartSub];
     }
 
     // 서버에 현재 방 참여를 알림
@@ -177,6 +219,25 @@ export const WebSocketProvider = ({ children }) => {
     });
     setJoinedRoomId(roomId);
   }, [joinedRoomId]);
+
+  // 재시작 요청 (방장이나 아무나 누를 수 있다고 가정)
+  const requestRestart = useCallback((roomId, userId) => {
+      if (clientRef.current && clientRef.current.connected) {
+          clientRef.current.publish({
+              destination: `/app/room/${roomId}/restart`,
+              body: JSON.stringify({ type: "RestartGame", roomId, userId })
+          });
+      }
+  }, []);
+  // 투표 응답
+  const sendVote = useCallback((roomId, userId, join) => {
+      if (clientRef.current && clientRef.current.connected) {
+          clientRef.current.publish({
+              destination: `/app/room/${roomId}/vote`,
+              body: JSON.stringify({ type: "Vote", roomId, userId, isJoin: join })
+          });
+      }
+  }, []);
 
   // 방 관련 구독과 상태를 정리하는 공통 함수
   const cleanupRoom = useCallback((roomId) => {
@@ -254,9 +315,10 @@ export const WebSocketProvider = ({ children }) => {
       });
     }
     // 서버가 퇴장 메시지를 처리할 시간을 조금 둔 뒤 구독을 정리한다.
-    setTimeout(() => cleanupRoom(roomId), 100);
-    currentUserIdRef.current = null;
-    cleanupRoom(roomId);
+    setTimeout(() => {
+      cleanupRoom(roomId);
+      currentUserIdRef.current = null;
+      }, 100);
   }, [cleanupRoom]);
 
   const resetForcedOut = useCallback(() => setForcedOut(false), []);
@@ -281,6 +343,10 @@ export const WebSocketProvider = ({ children }) => {
     forcedOut,
     resetForcedOut,
     clearSystemMessage,
+    requestRestart,
+    sendVote,
+    restartModal,
+    votes,
   };
 
   // 자식 컴포넌트들이 사용할 수 있도록 컨텍스트 제공


### PR DESCRIPTION
# Coby 재대결(Regame) 로직 흐름

이 문서는 Coby 프로젝트의 재대결 기능에 대한 기술적인 흐름을 설명합니다. 사용자의 요청부터 새로운 게임이 시작되기까지 프론트엔드와 백엔드 간의 REST API 및 WebSocket 통신 순서를 상세히 기술합니다.

## 등장 요소

-   **Frontend**: React 애플리케이션
    -   `ResultRoom.jsx`: 결과 페이지 UI, 재대결 요청 시작
    -   `WebSocketContext.jsx`: 모든 WebSocket 통신 관리
-   **Backend**: Spring Boot 애플리케이션
    -   `WebSocketController.java`: 클라이언트의 WebSocket 메시지 수신 및 처리
    -   `RestartService.java`: 실제 재시작 비즈니스 로직 수행

---

## 재대결 전체 흐름 (Sequence of Events)

### 1. [Frontend] 재대결 요청

-   **위치**: `ResultRoom.jsx`
-   **동작**: 사용자가 '재대결' 버튼을 클릭하면 `regameBtn` 함수가 실행됩니다.
-   **흐름**:
    1.  **(REST API)** 먼저 백엔드에 재시작이 가능한지 확인하기 위해 `POST` 요청을 보냅니다.
        -   **Endpoint**: `/api/rooms/restart/{roomId}`
    2.  **(WebSocket)** 그 직후, `requestRestart` 함수를 호출하여 모든 유저에게 재대결 의사를 묻는 투표를 시작하도록 웹소켓 메시지를 전송합니다.
        -   **Destination**: `/app/room/{roomId}/restart`
        -   **Payload**: `{ "type": "RestartGame", "userId": "..." }`

### 2. [Backend] 재대결 접수 및 투표 개시

-   **위치**: `WebSocketController.java` -> `RestartService.java`
-   **동작**: `/app/room/{roomId}/restart` 메시지를 수신하여 `handleRestart` 메소드가 실행됩니다.
-   **흐름**:
    1.  `RestartService`는 투표 관리를 위한 `RestartSession`을 생성합니다.
    2.  **12초**의 타임아웃을 설정하고, 시간이 만료되면 투표가 자동으로 종료되도록 예약합니다.
    3.  방에 있는 모든 클라이언트에게 투표 모달을 띄우라는 메시지를 전송합니다.
        -   **Destination**: `/topic/restart/{roomId}`
        -   **Payload**: `{ "type": "RestartStarted" }`

### 3. [Frontend] 투표 모달 표시

-   **위치**: `WebSocketContext.jsx` -> `ResultRoom.jsx`
-   **동작**: `/topic/restart/{roomId}` 구독을 통해 `RestartStarted` 메시지를 수신합니다.
-   **흐름**:
    1.  `WebSocketContext`는 `restartModal` 상태를 `true`로 변경합니다.
    2.  `ResultRoom`은 해당 상태 변화를 감지하여, 10초 카운트다운 타이머가 포함된 투표 모달을 화면에 렌더링합니다.

### 4. [Frontend] 사용자 투표

-   **위치**: `ResultRoom.jsx`
-   **동작**: 사용자가 모달에서 '수락' 또는 '거절' 버튼을 클릭합니다.
-   **흐름**:
    1.  `sendVote(roomId, userId, isJoin)` 함수가 호출됩니다. (`isJoin`은 `true` 또는 `false`)
    2.  서버에 투표 결과를 웹소켓 메시지로 전송합니다.
        -   **Destination**: `/app/room/{roomId}/vote`
        -   **Payload**: `{ "type": "Vote", "userId": "...", "isJoin": true/false }`

### 5. [Backend] 투표 처리 및 전파

-   **위치**: `WebSocketController.java` -> `RestartService.java`
-   **동작**: `/app/room/{roomId}/vote` 메시지를 수신하여 `handleVote` 메소드가 실행됩니다.
-   **흐름**:
    1.  `RestartService`는 `RestartSession`에 해당 유저의 투표(`true`/`false`)를 기록합니다.
    2.  누가 어떤 투표를 했는지 모든 클라이언트가 알 수 있도록, 투표 결과를 다시 브로드캐스팅합니다.
        -   **Destination**: `/topic/restart/{roomId}`
        -   **Payload**: `{ "type": "Vote", "userId": "...", "join": true/false }`
    3.  모든 유저가 투표했는지 확인하고, 만약 모두 투표했다면 즉시 **7번 단계**로 이동하여 투표를 종료합니다.

### 6. [Frontend] 실시간 투표 현황 업데이트

-   **위치**: `WebSocketContext.jsx` -> `ResultRoom.jsx`
-   **동작**: `/topic/restart/{roomId}` 구독을 통해 `Vote` 메시지를 수신합니다.
-   **흐름**:
    1.  `WebSocketContext`는 `votes` 상태를 업데이트하여 투표 현황을 저장합니다.
    2.  `ResultRoom`은 이 상태를 바탕으로 "ㅇㅇㅇ님: ✓ 수락" 과 같이 실시간 투표 현황을 화면에 갱신합니다.

### 7. [Backend] 투표 종료 및 결과 집계

-   **위치**: `RestartService.java`
-   **동작**: 다음 두 가지 경우 중 하나가 발생하면 `completeRestart` 메소드가 실행되어 투표를 종료합니다.
    1.  모든 참가자가 투표를 완료했을 때
    2.  서버에 설정된 **12초** 타임아웃이 만료되었을 때 (이때 투표하지 않은 유저는 '거절'로 간주)
-   **흐름**:
    -   **(전원 수락 시)**:
        1.  `createNewRoomFromOld` 메소드를 호출하여 새로운 방을 생성하고, 새 방의 ID(`newRoomId`)를 받아옵니다.
        2.  클라이언트에게 재시작 성공 및 새 방 ID 정보를 메시지로 전송합니다.
            -   **Destination**: `/topic/restart/{roomId}`
            -   **Payload**: `{ "type": "RestartResult", "success": true, "newRoomId": ... }`
    -   **(거절 또는 타임아웃 시)**:
        1.  클라이언트에게 재시작이 실패했음을 알리는 메시지를 전송합니다.
            -   **Destination**: `/topic/restart/{roomId}`
            -   **Payload**: `{ "type": "RestartResult", "success": false, "newRoomId": null }`

### 8. [Frontend] 결과 처리 및 페이지 이동

-   **위치**: `WebSocketContext.jsx` -> `ResultRoom.jsx`
-   **동작**: `/topic/restart/{roomId}` 구독을 통해 `RestartResult` 메시지를 수신합니다.
-   **흐름**:
    1.  우선, `leaveRoom(oldRoomId, ...)` 함수를 호출하여 **기존 방**에서 나간다는 `leave` 메시지를 서버에 전송합니다.
    2.  수신한 `RestartResult` 메시지를 분석합니다.
        -   **(성공 시)**: `newRoomId`가 있으면, `navigateToWaitingRoom` 이벤트를 발생시켜 모든 유저가 새 대기실(`/waitingRoom/{newRoomId}`)로 이동하게 합니다.
        -   **(실패 시)**: `newRoomId`가 `null`이면, `navigateToMain` 이벤트를 발생시켜 모든 유저가 메인 페이지(`/mainpage`)로 이동하게 합니다.
