### PR TITLE
fix: startAt 시간을 기준으로 하여 5초 카운트다운 하도록 추가

### DIFF
--- a/backend/src/main/java/com/example/coby/dto/WsMessageDto.java
+++ b/backend/src/main/java/com/example/coby/dto/WsMessageDto.java
@@ -23,5 +23,7 @@ public record WsMessageDto(
         List<RoomUserResponse> users,
         LocalDateTime startAt,
         LocalDateTime expireAt,
-        Long timeLimitSeconds
+        Long timeLimitSeconds,
+        Long gameStartDelaySeconds
+
 ) {}

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,7 +5,7 @@ set -e
 JAR_NAME="coby-0.0.1-SNAPSHOT.jar"
 EC2_USER="ubuntu"
 EC2_HOST="54.180.197.9"
-EC2_KEY_PATH="~/projects/Capstone/coby_bastion.pem"
+EC2_KEY_PATH="d:/coby_bastion.pem"
 REACT_API_URL="https://cobyapp.kro.kr"
 
 # === 로그 출력 함수 ===

--- a/frontend/src/pages/WaitingRoom/WaitingRoom.jsx
+++ b/frontend/src/pages/WaitingRoom/WaitingRoom.jsx
@@ -53,6 +53,7 @@ function WaitingRoom() {
         systemMessage,
         clearSystemMessage,
         startAt,
+        gameStartDelaySeconds,
         recalculateRemainingTime,
     } = useWebSocket();
 

--- a/frontend/src/pages/WebSocket/WebSocketContext.jsx
+++ b/frontend/src/pages/WebSocket/WebSocketContext.jsx
@@ -41,6 +41,7 @@ export const WebSocketProvider = ({ children }) => {
   const [gameStartAt, setGameStartAt] = useState(null);
   const [gameExpireAt, setGameExpireAt] = useState(null);
   const [gameTimeLimitSeconds, setGameTimeLimitSeconds] = useState(null);
+  const [gameStartDelaySeconds, setGameStartDelaySeconds] = useState(null);
   const [remainingTimeMs, setRemainingTimeMs] = useState(null);
   const [gameExpired, setGameExpired] = useState(false);
   // 강퇴 여부 및 현재 사용자 ID를 저장
@@ -102,6 +103,7 @@ export const WebSocketProvider = ({ children }) => {
     setMessages([]);
     setUsers([]);
     setGameStart(false);
+    setGameStartDelaySeconds(null);
 
     // 방 정보에 대한 구독이 아직 없다면 생성
     if (!subscriptionsRef.current[roomId]) {
@@ -163,6 +165,14 @@ export const WebSocketProvider = ({ children }) => {
           case 'StartGame':
             setGameStart(true);
             setGameExpired(false);
+            if (typeof data.gameStartDelaySeconds === 'number') {
+              setGameStartDelaySeconds(data.gameStartDelaySeconds);
+            } else if (typeof data.gameStartDelaySeconds === 'string') {
+              const parsedDelay = Number.parseInt(data.gameStartDelaySeconds, 10);
+              setGameStartDelaySeconds(Number.isNaN(parsedDelay) ? null : parsedDelay);
+            } else {
+              setGameStartDelaySeconds(null);
+            }
             if (data.startAt) {
               const parsedStart = parseServerUtcMillis(data.startAt);
               setGameStartAt(Number.isNaN(parsedStart) ? null : parsedStart);
@@ -195,6 +205,7 @@ export const WebSocketProvider = ({ children }) => {
             setGameExpireAt(null);
             setGameTimeLimitSeconds(null);
             setRemainingTimeMs(0);
+            setGameStartDelaySeconds(null);
             break;
           default:
             break;
@@ -310,6 +321,7 @@ export const WebSocketProvider = ({ children }) => {
     setGameTimeLimitSeconds(null);
     setRemainingTimeMs(null);
     setGameExpired(false);
+    setGameStartDelaySeconds(null);
   }, []);
 
   // 채팅 메시지를 서버로 전송
@@ -434,6 +446,7 @@ export const WebSocketProvider = ({ children }) => {
     startAt: gameStartAt,
     expireAt: gameExpireAt,
     timeLimitSeconds: gameTimeLimitSeconds,
+    gameStartDelaySeconds,
     remainingTimeMs,
     remainingTimeSeconds,
     recalculateRemainingTime,


### PR DESCRIPTION
* 3초 딜레이를 주어서 startAt을 계산하도록 하고 이 시간과의 차이를 기반으로 카운트다운이 이루어지게 하였음.
* 테스트해보니까 서버 시간을 5초로 지연을 주면 클라이언트에서는 7초부터 카운트다운이 시작되어서, 적절히 조절해서 3초를 서버의 지연시간으로 설정하였음

closes #237 